### PR TITLE
prevent crash when reloading dev server, fix #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,12 +36,16 @@ module.exports.pitch = function(request) {
 	});
 	workerCompiler.runAsChild(function(err, entries, compilation) {
 		if(err) return callback(err);
-		var workerFile = entries[0].files[0];
-		var constructor = "new Worker(__webpack_public_path__ + " + JSON.stringify(workerFile) + ")";
-		if(query.inline) {
-			constructor = "require(" + JSON.stringify("!!" + path.join(__dirname, "createInlineWorker.js")) + ")(" +
-				JSON.stringify(compilation.assets[workerFile].source()) + ", __webpack_public_path__ + " + JSON.stringify(workerFile) + ")"
+		if (entries[0]) {
+			var workerFile = entries[0].files[0];
+			var constructor = "new Worker(__webpack_public_path__ + " + JSON.stringify(workerFile) + ")";
+			if(query.inline) {
+				constructor = "require(" + JSON.stringify("!!" + path.join(__dirname, "createInlineWorker.js")) + ")(" +
+					JSON.stringify(compilation.assets[workerFile].source()) + ", __webpack_public_path__ + " + JSON.stringify(workerFile) + ")"
+			}
+			return callback(null, "module.exports = function() {\n\treturn "+constructor+";\n};");
+		} else {
+			return callback(null, null);
 		}
-		return callback(null, "module.exports = function() {\n\treturn "+constructor+";\n};");
 	});
 }


### PR DESCRIPTION
just added an if/else clause to prevent some crashes like this :

not sure if return a callback with null,null is the correct solution but works

```sh
 10% 0/1 build modules
/Users/juju/Documents/projects/xxxxx/node_modules/worker-loader/index.js:39
		var workerFile = entries[0].files[0];
		                           ^
TypeError: Cannot read property 'files' of undefined
```