### PR TITLE
Fixes issue with relative include path

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports.pitch = function(request) {
 		if(err) return callback(err);
 		if (entries[0]) {
 			var workerFile = entries[0].files[0];
-			var constructor = "new Worker(__webpack_public_path__ + " + JSON.stringify(workerFile) + ")";
+			var constructor = "new Worker('/' + __webpack_public_path__ + " + JSON.stringify(workerFile) + ")";
 			if(query.inline) {
 				constructor = "require(" + JSON.stringify("!!" + path.join(__dirname, "createInlineWorker.js")) + ")(" +
 					JSON.stringify(compilation.assets[workerFile].source()) + ", __webpack_public_path__ + " + JSON.stringify(workerFile) + ")";


### PR DESCRIPTION
Fixes #10 

I noticed that the filename passed to the `Worker` constructor was relative to the current path. So for instance, if I am at `https://localhost:8080/path/to/page`, then when I attempt to import a worker file, with:

```
var MyWorker = require('worker!./worker.js');
```

then I see in the network console, that the file being loaded is `/path/to/ca85c43287fc2.worker.js`.

Now it turns out the worker actually lives at `/ca85c43287fc2.worker.js`, and so we actually want to link absolute rather than relative to the current page.

----

Here is a screenshot for reference:

![image](https://cloud.githubusercontent.com/assets/955154/12742986/5b1f8c18-c93f-11e5-8916-71331c8ec93d.png)
