### PR TITLE
Explicitly mark worker-loader as non-cacheable.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var loaderUtils = require("loader-utils");
 module.exports = function() {};
 module.exports.pitch = function(request) {
 	if(!this.webpack) throw new Error("Only usable with webpack");
+	this.cacheable(false);
 	var callback = this.async();
 	var query = loaderUtils.parseQuery(this.query);
 	var filename = loaderUtils.interpolateName(this, query.name || "[hash].worker.js", {


### PR DESCRIPTION
For webpack 2 compatibility in watch/hot-reload mode.