### PR TITLE
Add -loader suffix to README examples to reflect Webpack 2 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Import the worker file:
 
 ``` javascript
 // main.js
-var MyWorker = require("worker!./file.js");
+var MyWorker = require("worker-loader!./file.js");
 
 var worker = new MyWorker();
 worker.postMessage({a: 1});
@@ -18,7 +18,7 @@ worker.addEventListener("message", function(event) {...});
 
 You can also inline the worker as a blob with the `inline` parameter:
 ``` javascript
-var MyWorker = require("worker?inline!./file.js");
+var MyWorker = require("worker-loader?inline!./file.js");
 ```
 
 


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra 